### PR TITLE
Merge conflict mistakenly left teams as list not array. Fixed!

### DIFF
--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -16,7 +16,7 @@ namespace ScavengerWorld
         [Range(50, 10000)]
         [SerializeField]  private int maxStep = 1000;
         [SerializeField] private Interactable moveHereIfNoActionMarker;
-        [SerializeField] private List<TeamGroup> teams;
+        [SerializeField] private TeamGroup[] teams;
 
         private FoodSpawner foodSpawner;
         private int currentStep;


### PR DESCRIPTION
Lat merge conflict resolution mistakenly left TeamGroup.teams as list not array. Needed to be an array. Fixed!