### PR TITLE
Fixed non-moving training agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /[Bb]uilds/
 /[Ll]ogs/
 /[Uu]ser[Ss]ettings/
+/[Vv]env/
 
 # MemoryCaptures can get excessive in size.
 # They also could contain extremely sensitive data

--- a/Assets/Scripts/ActionRunner.cs
+++ b/Assets/Scripts/ActionRunner.cs
@@ -112,6 +112,7 @@ namespace ScavengerWorld
                     break;
                 case ActionType.none:
                     CurrentAction = null;
+                    mover.ResetNavigator();
                     break;
                 default:
                     break;
@@ -229,7 +230,6 @@ namespace ScavengerWorld
         {
             CurrentAction.IsRunning = false;
             CurrentAction = null;
-            mover.StopMoving();
         }
     }
 }

--- a/Assets/Scripts/Mover.cs
+++ b/Assets/Scripts/Mover.cs
@@ -136,5 +136,10 @@ namespace ScavengerWorld
             NavMesh.SamplePosition(randomPos, out NavMeshHit hit, explorationRange, NavMesh.AllAreas);
             return hit.position;
         }
+
+        public void ResetNavigator()
+        {
+            navigator.ResetPath();
+        }
     }
 }

--- a/Assets/Scripts/RL/TeamGroup.cs
+++ b/Assets/Scripts/RL/TeamGroup.cs
@@ -40,6 +40,7 @@ namespace ScavengerWorld.AI
                 agent.Unit.TeamId = teamId;
                 agent.Unit.Damageable.ResetHealth();
                 agent.Unit.ActionRunner.CancelCurrentAction();
+                agent.Unit.Mover.ResetNavigator();
                 agent.transform.position = storage.transform.position;                              
                 agent.gameObject.SetActive(true);
             }


### PR DESCRIPTION
- Agent wasn't moving during training because actionrunner was telling agent to stop moving everytime the currentaction changed
- Fixed to only reset navmeshagent path when environment resets instead of on every action change